### PR TITLE
18 - Use generic strings

### DIFF
--- a/src/vpk.cpp
+++ b/src/vpk.cpp
@@ -96,12 +96,14 @@ namespace VpkParser {
   }
 
   bool Vpk::fileExists(const std::filesystem::path& path) const {
-    return files.contains(path.extension().string()) && //
-      files.at(path.extension().string()).contains(path.parent_path().string()) && //
-      files.at(path.extension().string()).at(path.parent_path().string()).contains(path.stem().string());
+    return files.contains(path.extension().generic_string()) && //
+      files.at(path.extension().generic_string()).contains(path.parent_path().generic_string()) && //
+      files.at(path.extension().generic_string())
+        .at(path.parent_path().generic_string())
+        .contains(path.stem().generic_string());
   }
 
   const Vpk::File& Vpk::getFileMetadata(const std::filesystem::path& path) const {
-    return files.at(path.extension().string()).at(path.parent_path().string()).at(path.stem().string());
+    return files.at(path.extension().generic_string()).at(path.parent_path().generic_string()).at(path.stem().generic_string());
   }
 }


### PR DESCRIPTION
## Changes

- Uses `generic_string()` when casting any path part to a string

This fixes Windows support and is a blocker for #18 in the TASBox repo.